### PR TITLE
Add revision module (with uchaguzi fixes) and add core hooks needed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "plugins/soundcloud"]
 	path = plugins/soundcloud
 	url = git://github.com/ushahidi/ushahidi-soundcloud.git
+[submodule "plugins/revision"]
+	path = plugins/revision
+	url = git://github.com/rjmackay/Ushahidi-plugin-revision.git

--- a/application/models/incident.php
+++ b/application/models/incident.php
@@ -629,4 +629,16 @@ class Incident_Model extends ORM {
 		parent::delete();
 	}
 
+	/**
+	 * Overrides the default save method for the ORM.
+	 * 
+	 */
+	public function save()
+	{
+		// Fire an event on every save
+		Event::run('ushahidi_action.report_save', $this);
+		
+		parent::save();
+	}
+
 }


### PR DESCRIPTION
This plugin records full diff's of what changes each time a report is saved
it only handles core fields, not plugins (ie actionable) but its better
than just core.

Implementation isn't great: its saving serialized blobs and it may have some
effect on performance as revisions built up. If it looks like its a load issue
we can just disable the plugin.
